### PR TITLE
corrected dragging service enable draging in all directions using abs

### DIFF
--- a/flowchart/dragging_service.js
+++ b/flowchart/dragging_service.js
@@ -31,8 +31,8 @@ angular.module('dragging', ['mouseCapture', ] )
 	  		var mouseMove = function (evt) {
 
 				if (!dragging) {
-					if (evt.pageX - x > threshold ||
-						evt.pageY - y > threshold)
+					if (Math.abs(evt.pageX - x) > threshold ||
+						Math.abs(evt.pageY - y) > threshold)
 					{
 						dragging = true;
 


### PR DESCRIPTION
Hi (first time I create a pull request on github so if I did something wrong sorry ...), 

I realized using the flowchart that dragging wouldn't start when moving the mouse upward or to the left. The reason is  evt.pageX - x or evt.pageY - y would return negative negative value which do not trigger the test (more than threshold).  So I changed this using Math.Abs(evt.pageX - x) so it triggers dragging whatever direction you go. 

Very nice article and project thanks !
