### PR TITLE
Remove debug call from flowchart_viewmodel.js

### DIFF
--- a/flowchart/flowchart_viewmodel.js
+++ b/flowchart/flowchart_viewmodel.js
@@ -462,9 +462,6 @@ var flowchart = {
 		//
 		this.createNewConnection = function (sourceConnector, destConnector) {
 
-			debug.assertObjectValid(sourceConnector);
-			debug.assertObjectValid(destConnector);
-
 			var connectionsDataModel = this.data.connections;
 			if (!connectionsDataModel) {
 				connectionsDataModel = this.data.connections = [];


### PR DESCRIPTION
Call to `debug.assertObjectValid()` causes JS error when creating new connection (when `debug` utility is not defined, which by default isn't).

I believe this call shouldn't be in production.

Please consider merging this, thanks!
