### PR TITLE
Add `get` method to get custom fields from node data

### DIFF
--- a/flowchart/flowchart_viewmodel.js
+++ b/flowchart/flowchart_viewmodel.js
@@ -110,6 +110,13 @@ var flowchart = {
 		this._selected = false;
 
 		//
+		// Get custom variable from node's data.
+		//
+		this.get = function (key) {
+			return this.data[key];
+		};
+
+		//
 		// Name of the node.
 		//
 		this.name = function () {

--- a/flowchart/flowchart_viewmodel.spec.js
+++ b/flowchart/flowchart_viewmodel.spec.js
@@ -149,6 +149,17 @@ describe('flowchart-viewmodel', function () {
 		expect(testObject.name()).toBe(mockDataModel.name);
 	});
 
+	it('test get() of NodeViewModel', function () {
+
+		var mockDataModel = {
+			shape: "star",
+		};
+
+		var testObject = new flowchart.NodeViewModel(mockDataModel);
+
+		expect(testObject.get('shape')).toBe(mockDataModel.shape);
+	});
+
 	it('test name of NodeViewModel defaults to empty string', function () {
 
 		var mockDataModel = {};


### PR DESCRIPTION
I'm proposing to add a getter for custom fields in node data. This allows e.g. store color of a rectangle, which can be then respected in `flowchart_template.html`.

Example of my usage:
- I store a type of a node and then render it in different color
  ![image](https://cloud.githubusercontent.com/assets/5679032/3687058/98c85494-1321-11e4-92c5-18d8519dfb8a.png)
