### PR TITLE
Fix createNewConnection method

### DIFF
--- a/flowchart/flowchart_viewmodel.spec.js
+++ b/flowchart/flowchart_viewmodel.spec.js
@@ -1098,15 +1098,41 @@ describe('flowchart-viewmodel', function () {
 
 		var testObject = new flowchart.ChartViewModel(mockDataModel); 		
 
-		var sourceConnector = testObject.nodes[0].outputConnectors[0];
-		var destConnector = testObject.nodes[1].inputConnectors[1];
+		var startConnector = testObject.nodes[0].outputConnectors[0];
+		var endConnector = testObject.nodes[1].inputConnectors[1];
 
-		testObject.createNewConnection(sourceConnector, destConnector);
+		testObject.createNewConnection(startConnector, endConnector);
 
 		expect(testObject.connections.length).toBe(1);
 		var connection = testObject.connections[0];
-		expect(connection.source).toBe(sourceConnector);
-		expect(connection.dest).toBe(destConnector);
+		expect(connection.source).toBe(startConnector);
+		expect(connection.dest).toBe(endConnector);
+
+		expect(testObject.data.connections.length).toBe(1);
+		var connectionData = testObject.data.connections[0];
+		expect(connection.data).toBe(connectionData);
+
+		expect(connectionData.source.nodeID).toBe(5);
+		expect(connectionData.source.connectorIndex).toBe(0);
+		expect(connectionData.dest.nodeID).toBe(25);
+		expect(connectionData.dest.connectorIndex).toBe(1);
+	});
+
+	it('test create new connection from input to output', function () {
+
+		var mockDataModel = createMockDataModel([5, 25]);
+
+		var testObject = new flowchart.ChartViewModel(mockDataModel);
+
+		var startConnector = testObject.nodes[1].inputConnectors[1];
+		var endConnector = testObject.nodes[0].outputConnectors[0];
+
+		testObject.createNewConnection(startConnector, endConnector);
+
+		expect(testObject.connections.length).toBe(1);
+		var connection = testObject.connections[0];
+		expect(connection.source).toBe(endConnector);
+		expect(connection.dest).toBe(startConnector);
 
 		expect(testObject.data.connections.length).toBe(1);
 		var connectionData = testObject.data.connections[0];


### PR DESCRIPTION
Observe, that `connection` is created other way round drag from input connector to output connector in `master` version: https://dl.dropboxusercontent.com/u/16408368/WebUI_FlowChart/index.html

(note that in the dropbox version, you need to drag from connector to right and then left to connect connectors from input to output; in the most recent version, this dragging is fixed by 69af4a0d5eb19e20b6293752baae425a7602cd17)

This PR changes these things:
- Fix creating connections when drag goes from other way round (from input connector to output connector), so it doesn't matter if you drag from output connector to input connector or input connector to output connector.
- Disallow connecting 2 output connectors or 2 input connectors
- Disallow connecting a node with itself

Let me know if any questions.
