### PR TITLE
support self-defined node width

### DIFF
--- a/app.js
+++ b/app.js
@@ -65,6 +65,7 @@ angular.module('app', ['flowChart', ])
 				id: 0,
 				x: 0,
 				y: 0,
+				width: 350,
 				inputConnectors: [
 					{
 						name: "A",
@@ -200,27 +201,27 @@ angular.module('app', ['flowChart', ])
 			id: nextNodeID++,
 			x: 0,
 			y: 0,
-			inputConnectors: [ 
+			inputConnectors: [
 				{
-                    name: "X"
-                },
-                {
-                    name: "Y"
-                },
-                {
-                    name: "Z"
-                }			
+					name: "X"
+				},
+				{
+					name: "Y"
+				},
+				{
+					name: "Z"
+				}
 			],
 			outputConnectors: [ 
 				{
-                    name: "1"
-                },
-                {
-                    name: "2"
-                },
-                {
-                    name: "3"
-                }			
+					name: "1"
+				},
+				{
+					name: "2"
+				},
+				{
+					name: "3"
+				}
 			],
 		};
 

--- a/flowchart/flowchart_viewmodel.js
+++ b/flowchart/flowchart_viewmodel.js
@@ -12,7 +12,7 @@ var flowchart = {
 	//
 	// Width of a node.
 	//
-	flowchart.nodeWidth = 250;
+	flowchart.defaultNodeWidth = 250;
 
 	//
 	// Amount of space reserved for displaying the node's name.
@@ -36,7 +36,7 @@ var flowchart = {
 	//
 	flowchart.computeConnectorPos = function (node, connectorIndex, inputConnector) {
 		return {
-			x: node.x() + (inputConnector ? 0 : flowchart.nodeWidth),
+			x: node.x() + (inputConnector ? 0 : node.width ? node.width : flowchart.defaultNodeWidth),
 			y: node.y() + flowchart.computeConnectorY(connectorIndex),
 		};
 	};
@@ -103,8 +103,13 @@ var flowchart = {
 	flowchart.NodeViewModel = function (nodeDataModel) {
 
 		this.data = nodeDataModel;
+
+		// set the default width value of the node
+		if (!this.data.width || this.data.width < 0) {
+			this.data.width = flowchart.defaultNodeWidth;
+		}
 		this.inputConnectors = createConnectorsViewModel(this.data.inputConnectors, 0, this);
-		this.outputConnectors = createConnectorsViewModel(this.data.outputConnectors, flowchart.nodeWidth, this);
+		this.outputConnectors = createConnectorsViewModel(this.data.outputConnectors, this.data.width, this);
 
 		// Set to true when the node is selected.
 		this._selected = false;
@@ -134,7 +139,7 @@ var flowchart = {
 		// Width of the node.
 		//
 		this.width = function () {
-			return flowchart.nodeWidth;
+			return this.data.width;
 		}
 
 		//
@@ -208,7 +213,7 @@ var flowchart = {
 			if (!this.data.outputConnectors) {
 				this.data.outputConnectors = [];
 			}
-			this._addConnector(connectorDataModel, flowchart.nodeWidth, this.data.outputConnectors, this.outputConnectors);
+			this._addConnector(connectorDataModel, this.data.width, this.data.outputConnectors, this.outputConnectors);
 		};
 	};
 

--- a/flowchart/flowchart_viewmodel.spec.js
+++ b/flowchart/flowchart_viewmodel.spec.js
@@ -167,6 +167,57 @@ describe('flowchart-viewmodel', function () {
 		expect(testObject.selected()).toBe(false);
 	});
 
+	it('test node width is set by default', function () {
+
+		var mockDataModel = {};
+
+		var testObject = new flowchart.NodeViewModel(mockDataModel);
+
+		expect(testObject.width() === flowchart.defaultNodeWidth).toBe(true);
+	});
+
+	it('test node width is used', function () {
+
+		var mockDataModel = {"width": 900 };
+
+		var testObject = new flowchart.NodeViewModel(mockDataModel);
+
+		expect(testObject.width()).toBe(900);
+	});
+
+	it('test computeConnectorPos uses node width', function () {
+
+		var mockDataModel = {
+			x: function () {
+				return 10
+			},
+			y: function () {
+				return 15
+			},
+			"width": 900
+		};
+
+		var testObject = flowchart.computeConnectorPos(mockDataModel, 1, false);
+
+		expect(testObject.x).toBe(910);
+	});
+
+	it('test computeConnectorPos uses default node width', function () {
+
+		var mockDataModel = {
+			x: function () {
+				return 10
+			},
+			y: function () {
+				return 15
+			},
+		};
+
+		var testObject = flowchart.computeConnectorPos(mockDataModel, 1, false);
+
+		expect(testObject.x).toBe(flowchart.defaultNodeWidth + 10);
+	});
+
 	it('test node can be selected', function () {
 
 		var mockDataModel = {};


### PR DESCRIPTION
support to customize node width by add width property in node model. 

If width not specified, using default value 

Test cases are added to test this feature, works fine on my chrome

PS: there are some changes caused by "tab or spaces". I found that most of the code is using tab, so I replaced spaces with tab. Hope is is not an issue. Personally I use spaces (-:
