### PR TITLE
Fixed Issue with output connector

### DIFF
--- a/flowchart/flowchart_viewmodel.js
+++ b/flowchart/flowchart_viewmodel.js
@@ -195,6 +195,13 @@ var flowchart = {
 		}
 
 		//
+		// Internal function to add a connector.
+		this._deleteConnector = function (connectorID, x, connectorsDataModel, connectorsViewModel) {
+			connectorsDataModel.splice(connectorID, 1);
+			connectorsViewModel.splice(connectorID, 1);
+		}
+
+		//
 		// Add an input connector to the node.
 		//
 		this.addInputConnector = function (connectorDataModel) {
@@ -214,6 +221,24 @@ var flowchart = {
 				this.data.outputConnectors = [];
 			}
 			this._addConnector(connectorDataModel, this.data.width, this.data.outputConnectors, this.outputConnectors);
+		};
+
+		//
+		// Delete an input connector from the node.
+		//
+		this.deleteInputConnector = function (connectorID) {
+			if (this.data.inputConnectors) {
+				this._deleteConnector(connectorID, this.data.width, this.data.inputConnectors, this.inputConnectors);
+			}
+		};
+
+		//
+		// Delete an output connector from the node.
+		//
+		this.deleteOutputConnector = function (connectorID) {
+			if (this.data.outputConnectors) {
+				this._deleteConnector(connectorID, this.data.width, this.data.outputConnectors, this.outputConnectors);
+			}
 		};
 	};
 

--- a/flowchart/flowchart_viewmodel.js
+++ b/flowchart/flowchart_viewmodel.js
@@ -36,7 +36,7 @@ var flowchart = {
 	//
 	flowchart.computeConnectorPos = function (node, connectorIndex, inputConnector) {
 		return {
-			x: node.x() + (inputConnector ? 0 : node.width ? node.width : flowchart.defaultNodeWidth),
+			x: node.x() + (inputConnector ? 0 : node.width ? node.width() : flowchart.defaultNodeWidth),
 			y: node.y() + flowchart.computeConnectorY(connectorIndex),
 		};
 	};

--- a/flowchart/flowchart_viewmodel.spec.js
+++ b/flowchart/flowchart_viewmodel.spec.js
@@ -194,10 +194,15 @@ describe('flowchart-viewmodel', function () {
 			y: function () {
 				return 15
 			},
-			"width": 900
+			width: function() {
+				return 900
+			}
 		};
 
+		
 		var testObject = flowchart.computeConnectorPos(mockDataModel, 1, false);
+
+		console.log(testObject);
 
 		expect(testObject.x).toBe(910);
 	});

--- a/flowchart/flowchart_viewmodel.spec.js
+++ b/flowchart/flowchart_viewmodel.spec.js
@@ -199,10 +199,7 @@ describe('flowchart-viewmodel', function () {
 			}
 		};
 
-		
 		var testObject = flowchart.computeConnectorPos(mockDataModel, 1, false);
-
-		console.log(testObject);
 
 		expect(testObject.x).toBe(910);
 	});


### PR DESCRIPTION
Creating connection from output connector was not animating correctly.
Line was not drawn correctly from output connector to mouse.
Connection could be made but many errors were logged.

node.width was returning a function to calculate width instead of return the width.
Updated flowchart_viewmodel to execute the function, correctly getting the width and solving the issue.
Updated flowchart_viewmodel spec test to correctly mock the data model.