### PR TITLE
 For cross-browser compatibility, use window.pageYOffset instead of window.scrollY.

### DIFF
--- a/flowchart/flowchart_directive.js
+++ b/flowchart/flowchart_directive.js
@@ -185,8 +185,8 @@ angular.module('flowChart', ['dragging'] )
 		var svg_elem =  $element.get(0);
 		var matrix = svg_elem.getScreenCTM();
 		var point = svg_elem.createSVGPoint();
-		point.x = x - evt.view.scrollX;
-		point.y = y - evt.view.scrollY;
+		point.x = x - evt.view.pageXOffset;
+		point.y = y - evt.view.pageYOffset;
 		return point.matrixTransform(matrix.inverse());
 	};
 

--- a/flowchart/flowchart_directive.spec.js
+++ b/flowchart/flowchart_directive.spec.js
@@ -261,8 +261,8 @@ describe('flowchart-directive', function () {
 
 		var mockEvt = {
 			view: {
-				scrollX: 0,
-				scrollY: 0,
+				pageXOffset: 0,
+				pageYOffset: 0,
 			},
 		};
 


### PR DESCRIPTION
Fixes issue https://github.com/codecapers/AngularJS-FlowChart/issues/18 "Dragging nodes in IE10"